### PR TITLE
Call perror on uncknown errors in the MIDI queue.

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1200,7 +1200,8 @@ static void *alsaMidiHandler( void *ptr )
       continue;
     }
     else if ( result <= 0 ) {
-      std::cerr << "MidiInAlsa::alsaMidiHandler: unknown MIDI input error!\n";
+      std::cerr << "\nMidiInAlsa::alsaMidiHandler: unknown MIDI input error!\n";
+      perror("System reports");
       continue;
     }
 


### PR DESCRIPTION
Print system error report in case we don't understand the error from the system in the alsa MIDI handler.
