### PR TITLE
Fix compiling with C++11 - can't typedef a template, can't implicitly construct std::shared_ptr

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -39,7 +39,9 @@
 #include "RtMidi.h"
 #include <sstream>
 #include <cstring>
+#include <cctype>
 #include <algorithm>
+#include <functional>
 
 namespace rtmidi {
 #ifdef RTMIDI_GETTEXT
@@ -4365,8 +4367,7 @@ namespace rtmidi{
 		}
 		WinMMPortDescriptor * retval = NULL;
 		try {
-			retval = Pointer<PortDescriptor>(
-				new WinMMPortDescriptor(devid, getPortName(devid), true, data->getClientName()));
+			retval = new WinMMPortDescriptor(devid, getPortName(devid), true, data->getClientName());
 		} catch (Error e) {
 			try {
 				error(e);
@@ -4375,7 +4376,7 @@ namespace rtmidi{
 				throw;
 			}
 		}
-                return retval;
+                return Pointer<PortDescriptor>(retval);
 
 	}
 

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -3715,7 +3715,7 @@ namespace rtmidi {
 			} else {
 				if (data && data->client) {
 					return Pointer<PortDescriptor>(
-						new AlsaPortDescriptor(*data, data->getClientName())));
+						new AlsaPortDescriptor(*data, data->getClientName()));
 				}
 			}
 		} catch (Error e) {

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1465,8 +1465,8 @@ namespace rtmidi {
 				try {
 					if ((seq.getPortCapabilities(destination)
 					     & caps) == caps)
-						list.push_back(new CorePortDescriptor(destination,
-									      clientName));
+						list.push_back(Pointer<PortDescriptor>(
+							new CorePortDescriptor(destination, clientName)));
 				} catch (Error e) {
 					if (e.getType() == Error::WARNING ||
 					    e.getType() == Error::DEBUG_WARNING)
@@ -1486,8 +1486,8 @@ namespace rtmidi {
 				try {
 					if ((seq.getPortCapabilities(src)
 					     & caps) == caps)
-						list.push_back(new CorePortDescriptor(src,
-										      clientName));
+						list.push_back(Pointer<PortDescriptor>(
+							new CorePortDescriptor(src, clientName)));
 				} catch (Error e) {
 					if (e.getType() == Error::WARNING ||
 					    e.getType() == Error::DEBUG_WARNING)
@@ -1866,13 +1866,12 @@ namespace rtmidi {
 		}
 		if (local) {
 			if (data && data->localEndpoint) {
-				return new
-					CorePortDescriptor(data->localEndpoint,
-							   data->getClientName());
+				return Pointer<PortDescriptor>(new
+					CorePortDescriptor(data->localEndpoint, data->getClientName()));
 			}
 		} else {
 			if (data->getEndpoint()) {
-				return new CorePortDescriptor(*data);
+				return Pointer<PortDescriptor>(new CorePortDescriptor(*data));
 			}
 		}
 		return NULL;
@@ -2113,13 +2112,13 @@ namespace rtmidi {
 		try {
 			if (local) {
 				if (data && data->localEndpoint) {
-					return new
-						CorePortDescriptor(data->localEndpoint,
-								   data->getClientName());
+					return Pointer<PortDescriptor>(
+						new CorePortDescriptor(data->localEndpoint, data->getClientName()));
 				}
 			} else {
 				if (data->getEndpoint()) {
-					return new CorePortDescriptor(*data);
+					return Pointer<PortDescriptor>(
+						new CorePortDescriptor(*data));
 				}
 			}
 		} catch (Error e) {
@@ -2623,7 +2622,8 @@ namespace rtmidi {
 					    != (SND_SEQ_PORT_CAP_WRITE|SND_SEQ_PORT_CAP_SUBS_WRITE))
 						continue;
 				}
-				list.push_back(new AlsaPortDescriptor(client,snd_seq_port_info_get_port(pinfo),clientName));
+				list.push_back(Pointer<PortDescriptor>(
+					new AlsaPortDescriptor(client,snd_seq_port_info_get_port(pinfo),clientName)));
 			}
 		}
 		return list;
@@ -3301,11 +3301,13 @@ namespace rtmidi {
 		try {
 			if (local) {
 				if (data && data->local.client) {
-					return new AlsaPortDescriptor(data->local,data->getClientName());
+					return Pointer<PortDescriptor>(
+						new AlsaPortDescriptor(data->local,data->getClientName()));
 				}
 			} else {
 				if (data && data->client) {
-					return new AlsaPortDescriptor(*data,data->getClientName());
+					return Pointer<PortDescriptor>(
+						new AlsaPortDescriptor(*data,data->getClientName()));
 				}
 			}
 		} catch (Error e) {
@@ -3705,11 +3707,13 @@ namespace rtmidi {
 		try {
 			if (local) {
 				if (data && data->local.client) {
-					return new AlsaPortDescriptor(data->local, data->getClientName());
+					return Pointer<PortDescriptor>(
+						new AlsaPortDescriptor(data->local, data->getClientName()));
 				}
 			} else {
 				if (data && data->client) {
-					return new AlsaPortDescriptor(*data, data->getClientName());
+					return Pointer<PortDescriptor>(
+						new AlsaPortDescriptor(*data, data->getClientName())));
 				}
 			}
 		} catch (Error e) {
@@ -4022,13 +4026,15 @@ namespace rtmidi{
 			size_t n = midiInGetNumDevs();
 			for (size_t i = 0 ; i < n ; i++) {
 				std::string name = seq.getPortName(i,true,PortDescriptor::STORAGE_PATH);
-				list.push_back(new WinMMPortDescriptor(i,name,true,clientName));
+				list.push_back(Pointer<PortDescriptor>(
+					new WinMMPortDescriptor(i,name,true,clientName)));
 			}
 		} else {
 			size_t n = midiOutGetNumDevs();
 			for (size_t i = 0 ; i < n ; i++) {
 				std::string name = seq.getPortName(i,false,PortDescriptor::STORAGE_PATH);
-				list.push_back(new WinMMPortDescriptor(i,name,false,clientName));
+				list.push_back(Pointer<PortDescriptor>(
+					new WinMMPortDescriptor(i,name,false,clientName)));
 			}
 		}
 		return list;
@@ -4359,7 +4365,8 @@ namespace rtmidi{
 		}
 		WinMMPortDescriptor * retval = NULL;
 		try {
-			retval = new WinMMPortDescriptor(devid, getPortName(devid), true, data->getClientName());
+			retval = Pointer<PortDescriptor>(
+				new WinMMPortDescriptor(devid, getPortName(devid), true, data->getClientName()));
 		} catch (Error e) {
 			try {
 				error(e);
@@ -4626,7 +4633,8 @@ namespace rtmidi{
 					    Error::DRIVER_ERROR));
 			return 0;
 		}
-		return new WinMMPortDescriptor(devid, getPortName(devid), true, data->getClientName());
+		return Pointer<PortDescriptor>(
+			new WinMMPortDescriptor(devid, getPortName(devid), true, data->getClientName()));
 
 	}
 
@@ -5047,7 +5055,8 @@ namespace rtmidi {
 		const char ** ports = seq.getPortList(flags);
 		if (!ports) return list;
 		for (const char ** port = ports; *port; port++) {
-			list.push_back(new JackPortDescriptor(*port, clientName));
+			list.push_back(Pointer<PortDescriptor>(
+				new JackPortDescriptor(*port, clientName)));
 		}
 		jack_free(ports);
 		return list;
@@ -5451,11 +5460,13 @@ namespace rtmidi {
 		try {
 			if (local) {
 				if (data && data->local) {
-					return new JackPortDescriptor(data->local,data->getClientName());
+					return Pointer<PortDescriptor>(
+						new JackPortDescriptor(data->local,data->getClientName()));
 				}
 			} else {
 				if (data && *data) {
-					return new JackPortDescriptor(*data,data->getClientName());
+					return Pointer<PortDescriptor>(
+						new JackPortDescriptor(*data,data->getClientName()));
 				}
 			}
 		} catch (Error e) {
@@ -5665,11 +5676,13 @@ namespace rtmidi {
 		try {
 			if (local) {
 				if (data && data->local) {
-					return new JackPortDescriptor(data->local,data->getClientName());
+					return Pointer<PortDescriptor>(
+						new JackPortDescriptor(data->local,data->getClientName()));
 				}
 			} else {
 				if (data && *data) {
-					return new JackPortDescriptor(*data,data->getClientName());
+					return Pointer<PortDescriptor>(
+						new JackPortDescriptor(*data,data->getClientName()));
 				}
 			}
 		} catch (Error e) {

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -55,7 +55,7 @@
 #endif
 
 // Check for C++11 support
-#ifdef _MSC_VER && _MSC_VER >= 1800
+#if defined(_MSC_VER) && _MSC_VER >= 1800
 // At least Visual Studio 2013
 #define RTMIDI_SUPPORTS_CPP11 1
 #elif __cplusplus >= 201103L

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -54,6 +54,16 @@
 #define RTMIDI_DEPRECATED(func,message) func [[deprecated(message)]]
 #endif
 
+// Check for C++11 support
+#ifdef _MSC_VER && _MSC_VER >= 1800
+// At least Visual Studio 2013
+#define RTMIDI_SUPPORTS_CPP11 1
+#elif __cplusplus >= 201103L
+#define RTMIDI_SUPPORTS_CPP11 1
+#else
+#define RTMIDI_SUPPORTS_CPP11 0
+#endif
+
 #include <exception>
 #include <iostream>
 #include <string>
@@ -265,7 +275,7 @@ namespace rtmidi {
 
 
 
-#if __cplusplus < 201103L
+#if !RTMIDI_SUPPORTS_CPP11
 	class PortDescriptor;
 
 	template<class T>

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -335,7 +335,7 @@ namespace rtmidi {
 	};
 #else
 	template<class T>
-	typedef std::shared_ptr<T> Pointer;
+	using Pointer = std::shared_ptr<T>;
 #endif
 
 	class MidiApi;


### PR DESCRIPTION
- Must use using x = y instead of typedef.
- std::shared_ptr's constructor accepting a pointer is marked explicit, unlike the Pointer class. So, I have put in explicit constructors everywhere.

Only tested on OS X – will test on Windows & Linux(ALSA) soon.

As a sidenote – I’d really like to see this all merged into the official RtMidi, or at least as a "version 3" branch. You’ve done a good job of cleaning up a lot of things.
